### PR TITLE
chore: update build triggers

### DIFF
--- a/renovate.Dockerfile
+++ b/renovate.Dockerfile
@@ -6,11 +6,6 @@
 # makes lint happy
 FROM scratch
 
-
-# EOL: 2022-11-28
-# renovate: datasource=docker depName=php versioning=docker
-ENV PHP_VERSION=7.4.33
-
 # EOL: 2023-11-26
 # renovate: datasource=docker depName=php versioning=docker
 ENV PHP_VERSION=8.0.26
@@ -18,3 +13,7 @@ ENV PHP_VERSION=8.0.26
 # EOL: 2024-11-25
 # renovate: datasource=docker depName=php versioning=docker
 ENV PHP_VERSION=8.1.13
+
+# EOL: 2025-12-08
+# renovate: datasource=docker depName=php versioning=docker
+ENV PHP_VERSION=8.2.0


### PR DESCRIPTION
This PR:
- Drops PHP 7.4 as it has now reached EOL
- Adds PHP 8.2.