### PR TITLE
chore: update build trigger for 8.3.0

### DIFF
--- a/renovate.Dockerfile
+++ b/renovate.Dockerfile
@@ -17,3 +17,7 @@ ENV PHP_VERSION=8.1.25
 # EOL: 2025-12-08
 # renovate: datasource=docker depName=php versioning=docker
 ENV PHP_VERSION=8.2.12
+
+# EOL: 2026-11-23
+# renovate: datasource=docker depName=php versioning=docker
+ENV PHP_VERSION=8.3.0


### PR DESCRIPTION
PHP 8.3.0 just released

I believe this is blocked by https://github.com/php-build/php-build/pull/759